### PR TITLE
Expose richer server proxy helpers

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -640,6 +640,45 @@ interface Server {
      * @returns An array of Player objects.
      */
     getPlayers(): Player[];
+
+    /**
+     * Attempts to find an online player by their exact username.
+     * @param name The case-sensitive Minecraft username to search for.
+     * @returns The player proxy if the player is online, otherwise null.
+     */
+    getPlayer(name: string): Player | null;
+
+    /**
+     * Attempts to find an online player by UUID string.
+     * @param uuid The UUID of the player (with hyphens).
+     * @returns The player proxy if the player is online, otherwise null.
+     */
+    getPlayerByUuid(uuid: string): Player | null;
+
+    /**
+     * Checks whether a player with the given username is currently connected.
+     * @param name The username to search for.
+     * @returns True if the player is online, otherwise false.
+     */
+    hasPlayer(name: string): boolean;
+
+    /**
+     * Retrieves the usernames of all currently online players.
+     * @returns An array of usernames in login order.
+     */
+    getPlayerNames(): string[];
+
+    /**
+     * Executes a console command on the server.
+     * @param command The full command string to execute.
+     */
+    runCommand(command: string): void;
+
+    /**
+     * Sends an action bar message to every online player.
+     * @param message The message to display above the hotbar.
+     */
+    broadcastActionBar(message: string): void;
 }
 
 /**

--- a/server/src/main/java/com/moud/server/proxy/ServerProxy.java
+++ b/server/src/main/java/com/moud/server/proxy/ServerProxy.java
@@ -1,12 +1,23 @@
 package com.moud.server.proxy;
 
+import com.moud.server.api.exception.APIException;
+import com.moud.server.api.validation.APIValidator;
+import net.kyori.adventure.text.Component;
 import net.minestom.server.MinecraftServer;
+import net.minestom.server.entity.Player;
 import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.proxy.ProxyArray;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class ServerProxy {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServerProxy.class);
+    private final APIValidator validator = new APIValidator();
+
     @HostAccess.Export
     public void broadcast(String message) {
         MinecraftServer.getConnectionManager().getOnlinePlayers()
@@ -25,5 +36,66 @@ public class ServerProxy {
                 .map(PlayerProxy::new)
                 .collect(Collectors.toList());
         return new JsArrayProxy(playerList);
+    }
+
+    @HostAccess.Export
+    public PlayerProxy getPlayer(String username) {
+        validator.validateString(username, "username");
+        Player player = MinecraftServer.getConnectionManager().getPlayer(username);
+        return wrapPlayer(player);
+    }
+
+    @HostAccess.Export
+    public PlayerProxy getPlayerByUuid(String uuid) {
+        validator.validateString(uuid, "uuid");
+        try {
+            UUID parsed = UUID.fromString(uuid);
+            Player player = MinecraftServer.getConnectionManager().getPlayer(parsed);
+            return wrapPlayer(player);
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn("Attempted to lookup player with invalid UUID '{}'", uuid);
+            return null;
+        }
+    }
+
+    @HostAccess.Export
+    public boolean hasPlayer(String username) {
+        validator.validateString(username, "username");
+        return MinecraftServer.getConnectionManager().getPlayer(username) != null;
+    }
+
+    @HostAccess.Export
+    public ProxyArray getPlayerNames() {
+        List<String> names = MinecraftServer.getConnectionManager().getOnlinePlayers()
+                .stream()
+                .map(Player::getUsername)
+                .collect(Collectors.toList());
+        return new JsArrayProxy(names);
+    }
+
+    @HostAccess.Export
+    public void runCommand(String command) {
+        validator.validateString(command, "command");
+        try {
+            MinecraftServer.getCommandManager().execute(
+                    MinecraftServer.getCommandManager().getConsoleSender(),
+                    command
+            );
+        } catch (Exception e) {
+            LOGGER.error("Failed to execute console command '{}'", command, e);
+            throw new APIException("COMMAND_EXECUTION_FAILED", "Failed to execute command: " + command, e);
+        }
+    }
+
+    @HostAccess.Export
+    public void broadcastActionBar(String message) {
+        validator.validateString(message, "message");
+        Component component = Component.text(message);
+        MinecraftServer.getConnectionManager().getOnlinePlayers()
+                .forEach(player -> player.sendActionBar(component));
+    }
+
+    private PlayerProxy wrapPlayer(Player player) {
+        return player != null ? new PlayerProxy(player) : null;
     }
 }


### PR DESCRIPTION
## Summary
- expose additional player lookup, command execution, and action bar helpers on the server proxy for scripts
- expand the TypeScript SDK server interface with the new helpers so TypeScript developers can access them

## Testing
- :server:compileJava *(fails: missing slf4j/reflections/com.moud.api dependencies in network-engine module)*

------
https://chatgpt.com/codex/tasks/task_b_68da77abe190832390346f2975d5e8da