### PR TITLE
Ensure mesh proxies enable Veil lighting buffers

### DIFF
--- a/api/src/main/java/com/moud/api/rendering/mesh/Mesh.java
+++ b/api/src/main/java/com/moud/api/rendering/mesh/Mesh.java
@@ -1,0 +1,52 @@
+package com.moud.api.rendering.mesh;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Immutable representation of a mesh composed of one or more parts.
+ */
+public final class Mesh {
+    private final List<MeshPart> parts;
+    private final Map<String, MeshPart> partsById;
+
+    Mesh(List<MeshPart> parts) {
+        if (parts.isEmpty()) {
+            throw new IllegalArgumentException("A mesh must contain at least one part");
+        }
+        this.parts = List.copyOf(parts);
+        Map<String, MeshPart> map = new LinkedHashMap<>();
+        for (MeshPart part : parts) {
+            MeshPart existing = map.putIfAbsent(part.getId(), part);
+            if (existing != null) {
+                throw new IllegalArgumentException("Duplicate mesh part id: " + part.getId());
+            }
+        }
+        this.partsById = Collections.unmodifiableMap(map);
+    }
+
+    public static MeshBuilder builder() {
+        return new MeshBuilder();
+    }
+
+    public List<MeshPart> getParts() {
+        return parts;
+    }
+
+    public Optional<MeshPart> findPart(String id) {
+        Objects.requireNonNull(id, "id");
+        return Optional.ofNullable(partsById.get(id));
+    }
+
+    public MeshPart requirePart(String id) {
+        return findPart(id).orElseThrow(() -> new IllegalArgumentException("Unknown mesh part: " + id));
+    }
+
+    public MeshData toData() {
+        return MeshData.fromMesh(this);
+    }
+}

--- a/api/src/main/java/com/moud/api/rendering/mesh/MeshBuilder.java
+++ b/api/src/main/java/com/moud/api/rendering/mesh/MeshBuilder.java
@@ -1,0 +1,114 @@
+package com.moud.api.rendering.mesh;
+
+import com.moud.api.math.Vector3;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * Builder class for creating immutable {@link Mesh} instances.
+ */
+public final class MeshBuilder {
+    private final List<MeshPart> parts = new ArrayList<>();
+
+    public MeshBuilder part(String id, Consumer<MeshPartBuilder> configurer) {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(configurer, "configurer");
+        MeshPartBuilder builder = new MeshPartBuilder(id);
+        configurer.accept(builder);
+        parts.add(builder.build());
+        return this;
+    }
+
+    public Mesh build() {
+        return new Mesh(parts);
+    }
+
+    public static final class MeshPartBuilder {
+        private final String id;
+        private final List<MeshVertex> vertices = new ArrayList<>();
+        private final List<Integer> indices = new ArrayList<>();
+
+        private MeshPartBuilder(String id) {
+            this.id = id;
+        }
+
+        public MeshPartBuilder vertex(Consumer<MeshVertexBuilder> configurer) {
+            Objects.requireNonNull(configurer, "configurer");
+            MeshVertexBuilder builder = new MeshVertexBuilder();
+            configurer.accept(builder);
+            vertices.add(builder.build());
+            return this;
+        }
+
+        public MeshPartBuilder triangle(int a, int b, int c) {
+            indices.add(a);
+            indices.add(b);
+            indices.add(c);
+            return this;
+        }
+
+        public MeshPartBuilder quad(int a, int b, int c, int d) {
+            // Triangulate quad as two triangles for compatibility
+            triangle(a, b, c);
+            triangle(a, c, d);
+            return this;
+        }
+
+        private MeshPart build() {
+            if (vertices.isEmpty()) {
+                throw new IllegalStateException("A mesh part must contain at least one vertex");
+            }
+            int[] indexArray = indices.isEmpty() ? null : indices.stream().mapToInt(Integer::intValue).toArray();
+            return new MeshPart(id, vertices, indexArray);
+        }
+    }
+
+    public static final class MeshVertexBuilder {
+        private Vector3 position;
+        private Vector3 normal;
+        private float u;
+        private float v;
+        private boolean hasUv;
+
+        public MeshVertexBuilder position(float x, float y, float z) {
+            this.position = new Vector3(x, y, z);
+            return this;
+        }
+
+        public MeshVertexBuilder position(Vector3 position) {
+            this.position = Objects.requireNonNull(position, "position");
+            return this;
+        }
+
+        public MeshVertexBuilder normal(float x, float y, float z) {
+            this.normal = new Vector3(x, y, z);
+            return this;
+        }
+
+        public MeshVertexBuilder normal(Vector3 normal) {
+            this.normal = Objects.requireNonNull(normal, "normal");
+            return this;
+        }
+
+        public MeshVertexBuilder uv(float u, float v) {
+            this.u = u;
+            this.v = v;
+            this.hasUv = true;
+            return this;
+        }
+
+        private MeshVertex build() {
+            if (position == null) {
+                throw new IllegalStateException("Mesh vertex requires a position");
+            }
+            if (!hasUv) {
+                // Default to zero UVs if none were provided
+                this.u = 0.0f;
+                this.v = 0.0f;
+            }
+            return new MeshVertex(position, normal, u, v);
+        }
+    }
+}

--- a/api/src/main/java/com/moud/api/rendering/mesh/MeshData.java
+++ b/api/src/main/java/com/moud/api/rendering/mesh/MeshData.java
@@ -1,0 +1,105 @@
+package com.moud.api.rendering.mesh;
+
+import com.moud.api.math.Vector3;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Serializable representation of a {@link Mesh} that can be sent across the network.
+ */
+public final class MeshData {
+    private final List<PartData> parts;
+
+    public MeshData(List<PartData> parts) {
+        if (parts == null || parts.isEmpty()) {
+            throw new IllegalArgumentException("MeshData requires at least one part");
+        }
+        List<PartData> copy = new ArrayList<>(parts.size());
+        for (PartData part : parts) {
+            copy.add(Objects.requireNonNull(part, "part"));
+        }
+        this.parts = Collections.unmodifiableList(copy);
+    }
+
+    public List<PartData> parts() {
+        return parts;
+    }
+
+    public static MeshData fromMesh(Mesh mesh) {
+        Objects.requireNonNull(mesh, "mesh");
+        List<PartData> partData = new ArrayList<>();
+        for (MeshPart part : mesh.getParts()) {
+            List<VertexData> vertexData = new ArrayList<>(part.getVertexCount());
+            for (MeshVertex vertex : part.getVertices()) {
+                vertexData.add(new VertexData(vertex.getPosition(), vertex.getNormal(), vertex.getU(), vertex.getV()));
+            }
+            int[] indices = part.isIndexed() ? part.getIndices() : null;
+            partData.add(new PartData(part.getId(), vertexData, indices));
+        }
+        return new MeshData(partData);
+    }
+
+    public Mesh toMesh() {
+        MeshBuilder builder = Mesh.builder();
+        for (PartData part : parts) {
+            builder.part(part.id(), meshPartBuilder -> {
+                for (VertexData vertex : part.vertices()) {
+                    meshPartBuilder.vertex(vertexBuilder -> vertexBuilder
+                            .position(new Vector3(vertex.position()))
+                            .normal(new Vector3(vertex.normal()))
+                            .uv(vertex.u(), vertex.v()));
+                }
+                int[] indices = part.indices();
+                if (indices != null && indices.length > 0) {
+                    if (indices.length % 3 != 0) {
+                        throw new IllegalStateException(
+                                "MeshData part '" + part.id() + "' indices length must be a multiple of 3"
+                        );
+                    }
+                    for (int i = 0; i < indices.length; i += 3) {
+                        meshPartBuilder.triangle(indices[i], indices[i + 1], indices[i + 2]);
+                    }
+                }
+            });
+        }
+        return builder.build();
+    }
+
+    public PartData part(String id) {
+        for (PartData part : parts) {
+            if (part.id().equals(id)) {
+                return part;
+            }
+        }
+        return null;
+    }
+
+    public record PartData(String id, List<VertexData> vertices, int[] indices) {
+        public PartData {
+            Objects.requireNonNull(id, "id");
+            Objects.requireNonNull(vertices, "vertices");
+            vertices = List.copyOf(vertices);
+            indices = indices != null ? indices.clone() : null;
+        }
+
+        @Override
+        public List<VertexData> vertices() {
+            return Collections.unmodifiableList(vertices);
+        }
+
+        @Override
+        public int[] indices() {
+            return indices != null ? indices.clone() : null;
+        }
+    }
+
+    public record VertexData(Vector3 position, Vector3 normal, float u, float v) {
+        public VertexData {
+            position = new Vector3(Objects.requireNonNull(position, "position"));
+            normal = normal != null ? new Vector3(normal) : Vector3.up();
+        }
+    }
+}

--- a/api/src/main/java/com/moud/api/rendering/mesh/MeshPart.java
+++ b/api/src/main/java/com/moud/api/rendering/mesh/MeshPart.java
@@ -1,0 +1,40 @@
+package com.moud.api.rendering.mesh;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents a mesh sub-section with an optional index buffer.
+ */
+public final class MeshPart {
+    private final String id;
+    private final List<MeshVertex> vertices;
+    private final int[] indices;
+
+    MeshPart(String id, List<MeshVertex> vertices, int[] indices) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.vertices = List.copyOf(vertices);
+        this.indices = indices != null ? indices.clone() : null;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public List<MeshVertex> getVertices() {
+        return Collections.unmodifiableList(vertices);
+    }
+
+    public boolean isIndexed() {
+        return indices != null && indices.length > 0;
+    }
+
+    public int[] getIndices() {
+        return indices != null ? indices.clone() : null;
+    }
+
+    public int getVertexCount() {
+        return vertices.size();
+    }
+}

--- a/api/src/main/java/com/moud/api/rendering/mesh/MeshRegistry.java
+++ b/api/src/main/java/com/moud/api/rendering/mesh/MeshRegistry.java
@@ -1,0 +1,33 @@
+package com.moud.api.rendering.mesh;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Thread-safe registry for reusable meshes.
+ */
+public final class MeshRegistry {
+    private final Map<String, Mesh> meshes = new ConcurrentHashMap<>();
+
+    public Optional<Mesh> find(String id) {
+        return Optional.ofNullable(meshes.get(id));
+    }
+
+    public Mesh require(String id) {
+        return find(id).orElseThrow(() -> new IllegalArgumentException("Unknown mesh: " + id));
+    }
+
+    public void register(String id, Mesh mesh) {
+        meshes.put(id, mesh);
+    }
+
+    public void unregister(String id) {
+        meshes.remove(id);
+    }
+
+    public Collection<Mesh> all() {
+        return meshes.values();
+    }
+}

--- a/api/src/main/java/com/moud/api/rendering/mesh/MeshVertex.java
+++ b/api/src/main/java/com/moud/api/rendering/mesh/MeshVertex.java
@@ -1,0 +1,37 @@
+package com.moud.api.rendering.mesh;
+
+import com.moud.api.math.Vector3;
+import java.util.Objects;
+
+/**
+ * Represents a single vertex of a mesh.
+ */
+public final class MeshVertex {
+    private final Vector3 position;
+    private final Vector3 normal;
+    private final float u;
+    private final float v;
+
+    MeshVertex(Vector3 position, Vector3 normal, float u, float v) {
+        this.position = Objects.requireNonNull(position, "position");
+        this.normal = normal != null ? normal : Vector3.up();
+        this.u = u;
+        this.v = v;
+    }
+
+    public Vector3 getPosition() {
+        return position;
+    }
+
+    public Vector3 getNormal() {
+        return normal;
+    }
+
+    public float getU() {
+        return u;
+    }
+
+    public float getV() {
+        return v;
+    }
+}

--- a/api/src/main/java/com/moud/api/rendering/model/ModelLoader.java
+++ b/api/src/main/java/com/moud/api/rendering/model/ModelLoader.java
@@ -1,0 +1,13 @@
+package com.moud.api.rendering.model;
+
+import com.moud.api.rendering.mesh.Mesh;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Represents a strategy for loading meshes from an input stream.
+ */
+@FunctionalInterface
+public interface ModelLoader {
+    Mesh load(InputStream stream) throws IOException;
+}

--- a/api/src/main/java/com/moud/api/rendering/model/ModelLoaderRegistry.java
+++ b/api/src/main/java/com/moud/api/rendering/model/ModelLoaderRegistry.java
@@ -1,0 +1,33 @@
+package com.moud.api.rendering.model;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Registry of model loaders keyed by file extension.
+ */
+public final class ModelLoaderRegistry {
+    private final Map<String, ModelLoader> loaders = new ConcurrentHashMap<>();
+
+    public Optional<ModelLoader> find(String extension) {
+        if (extension == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(loaders.get(extension.toLowerCase()));
+    }
+
+    public ModelLoader require(String extension) {
+        return find(extension).orElseThrow(() -> new IllegalArgumentException("No loader for extension: " + extension));
+    }
+
+    public void register(String extension, ModelLoader loader) {
+        loaders.put(extension.toLowerCase(), loader);
+    }
+
+    public void unregister(String extension) {
+        if (extension != null) {
+            loaders.remove(extension.toLowerCase());
+        }
+    }
+}

--- a/api/src/main/java/com/moud/api/rendering/model/ModelLoaders.java
+++ b/api/src/main/java/com/moud/api/rendering/model/ModelLoaders.java
@@ -1,0 +1,21 @@
+package com.moud.api.rendering.model;
+
+import com.moud.api.rendering.model.loader.SimpleObjModelLoader;
+
+/**
+ * Provides a default registry for built-in model loaders.
+ */
+public final class ModelLoaders {
+    private static final ModelLoaderRegistry REGISTRY = new ModelLoaderRegistry();
+
+    static {
+        REGISTRY.register("obj", new SimpleObjModelLoader());
+    }
+
+    private ModelLoaders() {
+    }
+
+    public static ModelLoaderRegistry registry() {
+        return REGISTRY;
+    }
+}

--- a/api/src/main/java/com/moud/api/rendering/model/loader/SimpleObjModelLoader.java
+++ b/api/src/main/java/com/moud/api/rendering/model/loader/SimpleObjModelLoader.java
@@ -1,0 +1,172 @@
+package com.moud.api.rendering.model.loader;
+
+import com.moud.api.math.Vector3;
+import com.moud.api.rendering.mesh.Mesh;
+import com.moud.api.rendering.mesh.MeshBuilder;
+import com.moud.api.rendering.model.ModelLoader;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Minimal OBJ loader that supports positions, normals and texture coordinates.
+ *
+ * <p>This implementation is intentionally simple and designed to provide
+ * enough functionality for prototyping custom rendering.</p>
+ */
+public final class SimpleObjModelLoader implements ModelLoader {
+    private static final String DEFAULT_PART = "default";
+
+    @Override
+    public Mesh load(InputStream stream) throws IOException {
+        List<Vector3> positions = new ArrayList<>();
+        List<Vector3> normals = new ArrayList<>();
+        List<float[]> uvs = new ArrayList<>();
+        List<VertexData> builtVertices = new ArrayList<>();
+        Map<String, Integer> vertexLookup = new HashMap<>();
+        List<int[]> triangles = new ArrayList<>();
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+            String rawLine;
+            while ((rawLine = reader.readLine()) != null) {
+                String line = rawLine.trim();
+                if (line.isEmpty() || line.startsWith("#")) {
+                    continue;
+                }
+                String[] tokens = line.split("\\s+");
+                String keyword = tokens[0].toLowerCase(Locale.ROOT);
+                switch (keyword) {
+                    case "v" -> positions.add(parseVector(tokens));
+                    case "vn" -> normals.add(parseVector(tokens));
+                    case "vt" -> uvs.add(parseUv(tokens));
+                    case "f" -> parseFace(tokens, positions, normals, uvs, builtVertices, vertexLookup, triangles);
+                    default -> {
+                        // ignore unsupported tokens
+                    }
+                }
+            }
+        }
+
+        MeshBuilder builder = Mesh.builder();
+        builder.part(DEFAULT_PART, part -> {
+            for (VertexData vertex : builtVertices) {
+                part.vertex(v -> {
+                    v.position(vertex.position);
+                    if (vertex.normal != null) {
+                        v.normal(vertex.normal);
+                    }
+                    v.uv(vertex.u, vertex.v);
+                });
+            }
+            for (int[] tri : triangles) {
+                part.triangle(tri[0], tri[1], tri[2]);
+            }
+        });
+        return builder.build();
+    }
+
+    private static Vector3 parseVector(String[] tokens) {
+        if (tokens.length < 4) {
+            throw new IllegalArgumentException("Invalid vector definition");
+        }
+        return new Vector3(Float.parseFloat(tokens[1]), Float.parseFloat(tokens[2]), Float.parseFloat(tokens[3]));
+    }
+
+    private static float[] parseUv(String[] tokens) {
+        if (tokens.length < 3) {
+            throw new IllegalArgumentException("Invalid texture coordinate definition");
+        }
+        float u = Float.parseFloat(tokens[1]);
+        float v = Float.parseFloat(tokens[2]);
+        return new float[] {u, v};
+    }
+
+    private static void parseFace(
+            String[] tokens,
+            List<Vector3> positions,
+            List<Vector3> normals,
+            List<float[]> uvs,
+            List<VertexData> builtVertices,
+            Map<String, Integer> vertexLookup,
+            List<int[]> triangles
+    ) {
+        if (tokens.length < 4) {
+            throw new IllegalArgumentException("Face must specify at least three vertices");
+        }
+        List<Integer> faceIndices = new ArrayList<>();
+        for (int i = 1; i < tokens.length; i++) {
+            String vertexToken = tokens[i];
+            int index = vertexLookup.computeIfAbsent(vertexToken, key -> {
+                VertexReference ref = parseVertexReference(key);
+                Vector3 position = ref.resolvePosition(positions);
+                Vector3 normal = ref.resolveNormal(normals);
+                float[] uv = ref.resolveUv(uvs);
+                VertexData vertex = new VertexData(position, normal, uv != null ? uv[0] : 0.0f, uv != null ? uv[1] : 0.0f);
+                builtVertices.add(vertex);
+                return builtVertices.size() - 1;
+            });
+            faceIndices.add(index);
+        }
+
+        for (int i = 1; i + 1 < faceIndices.size(); i++) {
+            int a = faceIndices.get(0);
+            int b = faceIndices.get(i);
+            int c = faceIndices.get(i + 1);
+            triangles.add(new int[] {a, b, c});
+        }
+    }
+
+    private static VertexReference parseVertexReference(String token) {
+        String[] parts = token.split("/");
+        int positionIndex = parts.length > 0 && !parts[0].isEmpty() ? Integer.parseInt(parts[0]) : 0;
+        Integer uvIndex = parts.length > 1 && !parts[1].isEmpty() ? Integer.parseInt(parts[1]) : null;
+        Integer normalIndex = parts.length > 2 && !parts[2].isEmpty() ? Integer.parseInt(parts[2]) : null;
+        return new VertexReference(positionIndex, uvIndex, normalIndex);
+    }
+
+    private record VertexData(Vector3 position, Vector3 normal, float u, float v) {
+    }
+
+    private record VertexReference(int positionIndex, Integer uvIndex, Integer normalIndex) {
+        private Vector3 resolvePosition(List<Vector3> positions) {
+            int index = normalizeIndex(positionIndex, positions.size());
+            return positions.get(index);
+        }
+
+        private Vector3 resolveNormal(List<Vector3> normals) {
+            if (normalIndex == null || normals.isEmpty()) {
+                return null;
+            }
+            int index = normalizeIndex(normalIndex, normals.size());
+            return normals.get(index);
+        }
+
+        private float[] resolveUv(List<float[]> uvs) {
+            if (uvIndex == null || uvs.isEmpty()) {
+                return null;
+            }
+            int index = normalizeIndex(uvIndex, uvs.size());
+            return uvs.get(index);
+        }
+
+        private static int normalizeIndex(int objIndex, int size) {
+            int resolved = objIndex;
+            if (resolved < 0) {
+                resolved = size + resolved;
+            } else {
+                resolved = resolved - 1;
+            }
+            if (resolved < 0 || resolved >= size) {
+                throw new IndexOutOfBoundsException("Invalid OBJ index: " + objIndex + " for size " + size);
+            }
+            return resolved;
+        }
+    }
+}

--- a/client-mod/src/main/java/com/moud/client/rendering/mesh/ClientMeshInstance.java
+++ b/client-mod/src/main/java/com/moud/client/rendering/mesh/ClientMeshInstance.java
@@ -1,0 +1,62 @@
+package com.moud.client.rendering.mesh;
+
+import com.moud.api.math.Vector3;
+import com.moud.api.rendering.mesh.Mesh;
+import net.minecraft.util.math.BlockPos;
+
+public final class ClientMeshInstance {
+    private final long id;
+    private Mesh mesh;
+    private Vector3 position;
+    private Vector3 rotation;
+    private Vector3 scale;
+
+    public ClientMeshInstance(long id, Mesh mesh, Vector3 position, Vector3 rotation, Vector3 scale) {
+        this.id = id;
+        this.mesh = mesh;
+        this.position = new Vector3(position != null ? position : Vector3.zero());
+        this.rotation = new Vector3(rotation != null ? rotation : Vector3.zero());
+        this.scale = new Vector3(scale != null ? scale : Vector3.one());
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public Mesh getMesh() {
+        return mesh;
+    }
+
+    public void updateMesh(Mesh mesh) {
+        this.mesh = mesh;
+    }
+
+    public Vector3 getPosition() {
+        return new Vector3(position);
+    }
+
+    public Vector3 getRotation() {
+        return new Vector3(rotation);
+    }
+
+    public Vector3 getScale() {
+        return new Vector3(scale);
+    }
+
+    public void updateTransform(Vector3 position, Vector3 rotation, Vector3 scale) {
+        if (position != null) {
+            this.position = new Vector3(position);
+        }
+        if (rotation != null) {
+            this.rotation = new Vector3(rotation);
+        }
+        if (scale != null) {
+            this.scale = new Vector3(scale);
+        }
+    }
+
+    public BlockPos getBlockPos() {
+        Vector3 pos = position;
+        return BlockPos.ofFloored(pos.x, pos.y, pos.z);
+    }
+}

--- a/client-mod/src/main/java/com/moud/client/rendering/mesh/ClientMeshManager.java
+++ b/client-mod/src/main/java/com/moud/client/rendering/mesh/ClientMeshManager.java
@@ -1,0 +1,57 @@
+package com.moud.client.rendering.mesh;
+
+import com.moud.api.math.Vector3;
+import com.moud.api.rendering.mesh.Mesh;
+import com.moud.api.rendering.mesh.MeshData;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class ClientMeshManager {
+    private static final ClientMeshManager INSTANCE = new ClientMeshManager();
+
+    private final Map<Long, ClientMeshInstance> meshes = new ConcurrentHashMap<>();
+
+    private ClientMeshManager() {
+    }
+
+    public static ClientMeshManager getInstance() {
+        return INSTANCE;
+    }
+
+    public ClientMeshInstance upsert(long meshId, MeshData data, Vector3 position, Vector3 rotation, Vector3 scale) {
+        Mesh mesh = data.toMesh();
+        return meshes.compute(meshId, (id, existing) -> {
+            if (existing == null) {
+                return new ClientMeshInstance(id, mesh, position, rotation, scale);
+            }
+            existing.updateMesh(mesh);
+            existing.updateTransform(position, rotation, scale);
+            return existing;
+        });
+    }
+
+    public void updateTransform(long meshId, Vector3 position, Vector3 rotation, Vector3 scale) {
+        ClientMeshInstance instance = meshes.get(meshId);
+        if (instance != null) {
+            instance.updateTransform(position, rotation, scale);
+        }
+    }
+
+    public void remove(long meshId) {
+        meshes.remove(meshId);
+    }
+
+    public Collection<ClientMeshInstance> getMeshes() {
+        return meshes.values();
+    }
+
+    public boolean isEmpty() {
+        return meshes.isEmpty();
+    }
+
+    public void clear() {
+        meshes.clear();
+    }
+}

--- a/client-mod/src/main/java/com/moud/client/rendering/mesh/ClientMeshRenderer.java
+++ b/client-mod/src/main/java/com/moud/client/rendering/mesh/ClientMeshRenderer.java
@@ -1,0 +1,119 @@
+package com.moud.client.rendering.mesh;
+
+import com.moud.api.math.Vector3;
+import com.moud.api.rendering.mesh.Mesh;
+import com.moud.api.rendering.mesh.MeshPart;
+import com.moud.api.rendering.mesh.MeshVertex;
+import foundry.veil.api.client.render.VeilRenderSystem;
+import foundry.veil.api.client.render.dynamicbuffer.DynamicBufferType;
+import net.minecraft.client.render.OverlayTexture;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.RotationAxis;
+import org.joml.Matrix3f;
+import org.joml.Matrix4f;
+import org.joml.Vector3f;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public final class ClientMeshRenderer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClientMeshRenderer.class);
+    private static final Identifier VEIL_BUFFER_ID = Identifier.of("moud", "mesh_proxies");
+
+    private boolean veilBuffersEnabled;
+
+    public void beginFrame() {
+        if (!veilBuffersEnabled) {
+            try {
+                VeilRenderSystem.renderer().enableBuffers(VEIL_BUFFER_ID,
+                        DynamicBufferType.ALBEDO, DynamicBufferType.NORMAL);
+                veilBuffersEnabled = true;
+            } catch (Exception e) {
+                LOGGER.warn("Failed to enable Veil buffers for mesh rendering", e);
+            }
+        }
+    }
+
+    public void disableVeilBuffers() {
+        if (veilBuffersEnabled) {
+            try {
+                VeilRenderSystem.renderer().disableBuffers(VEIL_BUFFER_ID,
+                        DynamicBufferType.ALBEDO, DynamicBufferType.NORMAL);
+            } catch (Exception e) {
+                LOGGER.warn("Failed to disable Veil buffers for mesh rendering", e);
+            }
+            veilBuffersEnabled = false;
+        }
+    }
+
+    public void render(ClientMeshInstance instance, MatrixStack matrices, VertexConsumerProvider consumers, int light) {
+        beginFrame();
+
+        Mesh mesh = instance.getMesh();
+        if (mesh == null) {
+            return;
+        }
+
+        Vector3 rotation = instance.getRotation();
+        Vector3 scale = instance.getScale();
+
+        matrices.push();
+        matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(rotation.x));
+        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(rotation.y));
+        matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(rotation.z));
+        matrices.scale(scale.x, scale.y, scale.z);
+
+        MatrixStack.Entry entry = matrices.peek();
+        Matrix4f positionMatrix = entry.getPositionMatrix();
+        Matrix3f normalMatrix = entry.getNormalMatrix();
+
+        VertexConsumer consumer = consumers.getBuffer(RenderLayer.getSolid());
+
+        for (MeshPart part : mesh.getParts()) {
+            emitPart(consumer, positionMatrix, normalMatrix, light, part.getVertices(), part.getIndices());
+        }
+
+        matrices.pop();
+    }
+
+    private void emitPart(VertexConsumer consumer, Matrix4f matrix, Matrix3f normalMatrix, int light,
+                          List<MeshVertex> vertices, int[] indices) {
+        if (vertices.isEmpty()) {
+            return;
+        }
+
+        if (indices != null && indices.length >= 3) {
+            int max = indices.length - (indices.length % 3);
+            for (int i = 0; i < max; i += 3) {
+                emitVertex(consumer, matrix, normalMatrix, light, vertices.get(indices[i]));
+                emitVertex(consumer, matrix, normalMatrix, light, vertices.get(indices[i + 1]));
+                emitVertex(consumer, matrix, normalMatrix, light, vertices.get(indices[i + 2]));
+            }
+        } else {
+            int max = vertices.size() - (vertices.size() % 3);
+            for (int i = 0; i < max; i += 3) {
+                emitVertex(consumer, matrix, normalMatrix, light, vertices.get(i));
+                emitVertex(consumer, matrix, normalMatrix, light, vertices.get(i + 1));
+                emitVertex(consumer, matrix, normalMatrix, light, vertices.get(i + 2));
+            }
+        }
+    }
+
+    private void emitVertex(VertexConsumer consumer, Matrix4f matrix, Matrix3f normalMatrix, int light, MeshVertex vertex) {
+        Vector3 position = vertex.getPosition();
+        Vector3 normal = vertex.getNormal();
+        Vector3f transformedNormal = new Vector3f(normal.x, normal.y, normal.z);
+        transformedNormal.mul(normalMatrix);
+        consumer.vertex(matrix, position.x, position.y, position.z)
+                .color(255, 255, 255, 255)
+                .texture(vertex.getU(), vertex.getV())
+                .overlay(OverlayTexture.DEFAULT_UV)
+                .light(light)
+                .normal(transformedNormal.x(), transformedNormal.y(), transformedNormal.z());
+    }
+}

--- a/client-mod/src/main/java/com/moud/client/rendering/model/ClientModelManager.java
+++ b/client-mod/src/main/java/com/moud/client/rendering/model/ClientModelManager.java
@@ -1,0 +1,57 @@
+package com.moud.client.rendering.model;
+
+import com.moud.api.rendering.mesh.Mesh;
+import com.moud.api.rendering.model.ModelLoader;
+import com.moud.api.rendering.model.ModelLoaderRegistry;
+import com.moud.api.rendering.model.ModelLoaders;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Client-side helper for loading meshes using the shared model loader registry.
+ */
+public final class ClientModelManager {
+    private final ModelLoaderRegistry registry;
+
+    public ClientModelManager() {
+        this(ModelLoaders.registry());
+    }
+
+    public ClientModelManager(ModelLoaderRegistry registry) {
+        this.registry = Objects.requireNonNull(registry, "registry");
+    }
+
+    public Mesh load(String identifier, Supplier<InputStream> streamSupplier) throws IOException {
+        Objects.requireNonNull(identifier, "identifier");
+        Objects.requireNonNull(streamSupplier, "streamSupplier");
+        String extension = extractExtension(identifier)
+                .orElseThrow(() -> new IllegalArgumentException("Identifier has no extension: " + identifier));
+        ModelLoader loader = registry.require(extension);
+        try (InputStream stream = streamSupplier.get()) {
+            if (stream == null) {
+                throw new IOException("Resource not found: " + identifier);
+            }
+            return loader.load(stream);
+        }
+    }
+
+    public void registerLoader(String extension, ModelLoader loader) {
+        registry.register(extension, loader);
+    }
+
+    public void unregisterLoader(String extension) {
+        registry.unregister(extension);
+    }
+
+    private static Optional<String> extractExtension(String identifier) {
+        int lastDot = identifier.lastIndexOf('.');
+        if (lastDot == -1 || lastDot == identifier.length() - 1) {
+            return Optional.empty();
+        }
+        return Optional.of(identifier.substring(lastDot + 1).toLowerCase(Locale.ROOT));
+    }
+}

--- a/network-engine/build.gradle
+++ b/network-engine/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+    id 'java'
+}
+
+dependencies {
+    implementation project(':api')
+    implementation 'org.slf4j:slf4j-api:2.0.9'
+    implementation 'org.reflections:reflections:0.10.2'
+}

--- a/network-engine/src/main/java/com/moud/network/MoudPackets.java
+++ b/network-engine/src/main/java/com/moud/network/MoudPackets.java
@@ -1,6 +1,7 @@
 package com.moud.network;
 
 import com.moud.api.math.Vector3;
+import com.moud.api.rendering.mesh.MeshData;
 import com.moud.network.annotation.Direction;
 import com.moud.network.annotation.Field;
 import com.moud.network.annotation.Packet;
@@ -79,6 +80,29 @@ public final class MoudPackets {
 
     @Packet(value = "moud:player_model_remove", direction = Direction.SERVER_TO_CLIENT)
     public record PlayerModelRemovePacket(@Field(order = 0) long modelId) {
+    }
+
+    @Packet(value = "moud:mesh_create", direction = Direction.SERVER_TO_CLIENT)
+    public record MeshCreatePacket(
+            @Field(order = 0) long meshId,
+            @Field(order = 1) MeshData data,
+            @Field(order = 2) Vector3 position,
+            @Field(order = 3) Vector3 rotation,
+            @Field(order = 4) Vector3 scale
+    ) {
+    }
+
+    @Packet(value = "moud:mesh_transform", direction = Direction.SERVER_TO_CLIENT)
+    public record MeshTransformPacket(
+            @Field(order = 0) long meshId,
+            @Field(order = 1) Vector3 position,
+            @Field(order = 2) Vector3 rotation,
+            @Field(order = 3) Vector3 scale
+    ) {
+    }
+
+    @Packet(value = "moud:mesh_remove", direction = Direction.SERVER_TO_CLIENT)
+    public record MeshRemovePacket(@Field(order = 0) long meshId) {
     }
 
     @Packet(value = "moud:sync_shared_values", direction = Direction.SERVER_TO_CLIENT)

--- a/server/src/main/java/com/moud/server/proxy/MeshProxy.java
+++ b/server/src/main/java/com/moud/server/proxy/MeshProxy.java
@@ -1,0 +1,241 @@
+package com.moud.server.proxy;
+
+import com.moud.api.math.Vector3;
+import com.moud.api.rendering.mesh.Mesh;
+import com.moud.api.rendering.mesh.MeshData;
+import com.moud.network.MoudPackets;
+import com.moud.server.network.ServerPacketWrapper;
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.entity.Player;
+import net.minestom.server.event.player.PlayerSpawnEvent;
+import org.graalvm.polyglot.HostAccess;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class MeshProxy {
+    private static final AtomicLong ID_COUNTER = new AtomicLong(1L);
+    private static final Map<Long, MeshProxy> ALL_MESHES = new ConcurrentHashMap<>();
+
+    static {
+        MinecraftServer.getGlobalEventHandler().addListener(PlayerSpawnEvent.class, event -> {
+            if (!event.isFirstSpawn()) {
+                return;
+            }
+            Player player = event.getPlayer();
+            UUID playerId = player.getUuid();
+            for (MeshProxy proxy : ALL_MESHES.values()) {
+                if (proxy.shouldSendTo(playerId)) {
+                    proxy.sendCreate(player);
+                }
+            }
+        });
+    }
+
+    private final long meshId;
+    private MeshData meshData;
+    private Vector3 position;
+    private Vector3 rotation;
+    private Vector3 scale;
+    private final Set<UUID> viewers = ConcurrentHashMap.newKeySet();
+    private final Set<UUID> hiddenPlayers = ConcurrentHashMap.newKeySet();
+    private volatile boolean visibleToAll;
+
+    public MeshProxy(Mesh mesh, Vector3 position, Vector3 rotation, Vector3 scale) {
+        this.meshId = ID_COUNTER.getAndIncrement();
+        this.meshData = MeshData.fromMesh(mesh);
+        this.position = copyVector(position, Vector3.zero());
+        this.rotation = copyVector(rotation, Vector3.zero());
+        this.scale = copyVector(scale, Vector3.one());
+        this.visibleToAll = false;
+        ALL_MESHES.put(meshId, this);
+    }
+
+    private static Vector3 copyVector(Vector3 value, Vector3 fallback) {
+        return value != null ? new Vector3(value) : new Vector3(fallback);
+    }
+
+    private boolean shouldSendTo(UUID uuid) {
+        if (visibleToAll) {
+            return !hiddenPlayers.contains(uuid);
+        }
+        return viewers.contains(uuid);
+    }
+
+    private Collection<Player> targetPlayers() {
+        if (visibleToAll) {
+            Collection<Player> players = MinecraftServer.getConnectionManager().getOnlinePlayers();
+            if (hiddenPlayers.isEmpty()) {
+                return players;
+            }
+            List<Player> filtered = new ArrayList<>();
+            for (Player player : players) {
+                if (!hiddenPlayers.contains(player.getUuid())) {
+                    filtered.add(player);
+                }
+            }
+            return filtered;
+        }
+
+        List<Player> players = new ArrayList<>();
+        for (UUID viewer : viewers) {
+            Player player = findPlayer(viewer);
+            if (player != null) {
+                players.add(player);
+            }
+        }
+        return players;
+    }
+
+    private void sendPacketToTargets(Object packet) {
+        Collection<Player> targets = targetPlayers();
+        if (targets.isEmpty()) {
+            return;
+        }
+        for (Player player : targets) {
+            player.sendPacket(ServerPacketWrapper.createPacket(packet));
+        }
+    }
+
+    private void sendCreate(Player player) {
+        MoudPackets.MeshCreatePacket packet = new MoudPackets.MeshCreatePacket(
+                meshId,
+                meshData,
+                new Vector3(position),
+                new Vector3(rotation),
+                new Vector3(scale)
+        );
+        player.sendPacket(ServerPacketWrapper.createPacket(packet));
+    }
+
+    private void broadcastCreate() {
+        sendPacketToTargets(new MoudPackets.MeshCreatePacket(
+                meshId,
+                meshData,
+                new Vector3(position),
+                new Vector3(rotation),
+                new Vector3(scale)
+        ));
+    }
+
+    private void broadcastTransform() {
+        sendPacketToTargets(new MoudPackets.MeshTransformPacket(
+                meshId,
+                new Vector3(position),
+                new Vector3(rotation),
+                new Vector3(scale)
+        ));
+    }
+
+    private void broadcastRemove() {
+        sendPacketToTargets(new MoudPackets.MeshRemovePacket(meshId));
+    }
+
+    @HostAccess.Export
+    public long getMeshId() {
+        return meshId;
+    }
+
+    @HostAccess.Export
+    public void showToAll() {
+        visibleToAll = true;
+        viewers.clear();
+        hiddenPlayers.clear();
+        Collection<Player> players = MinecraftServer.getConnectionManager().getOnlinePlayers();
+        for (Player player : players) {
+            sendCreate(player);
+        }
+    }
+
+    @HostAccess.Export
+    public void hideFromAll() {
+        broadcastRemove();
+        visibleToAll = false;
+        viewers.clear();
+        hiddenPlayers.clear();
+    }
+
+    @HostAccess.Export
+    public void showTo(PlayerProxy playerProxy) {
+        UUID uuid = UUID.fromString(playerProxy.getUuid());
+        hiddenPlayers.remove(uuid);
+        viewers.add(uuid);
+        Player player = findPlayer(uuid);
+        if (player != null) {
+            sendCreate(player);
+        }
+    }
+
+    @HostAccess.Export
+    public void hideFrom(PlayerProxy playerProxy) {
+        UUID uuid = UUID.fromString(playerProxy.getUuid());
+        viewers.remove(uuid);
+        hiddenPlayers.add(uuid);
+        Player player = findPlayer(uuid);
+        if (player != null) {
+            player.sendPacket(ServerPacketWrapper.createPacket(new MoudPackets.MeshRemovePacket(meshId)));
+        }
+    }
+
+    private Player findPlayer(UUID uuid) {
+        for (Player player : MinecraftServer.getConnectionManager().getOnlinePlayers()) {
+            if (player.getUuid().equals(uuid)) {
+                return player;
+            }
+        }
+        return null;
+    }
+
+    @HostAccess.Export
+    public void setPosition(Vector3 position) {
+        this.position = copyVector(position, this.position);
+        broadcastTransform();
+    }
+
+    @HostAccess.Export
+    public Vector3 getPosition() {
+        return new Vector3(position);
+    }
+
+    @HostAccess.Export
+    public void setRotation(Vector3 rotation) {
+        this.rotation = copyVector(rotation, this.rotation);
+        broadcastTransform();
+    }
+
+    @HostAccess.Export
+    public Vector3 getRotation() {
+        return new Vector3(rotation);
+    }
+
+    @HostAccess.Export
+    public void setScale(Vector3 scale) {
+        this.scale = copyVector(scale, this.scale);
+        broadcastTransform();
+    }
+
+    @HostAccess.Export
+    public Vector3 getScale() {
+        return new Vector3(scale);
+    }
+
+    @HostAccess.Export
+    public void setMesh(Mesh mesh) {
+        this.meshData = MeshData.fromMesh(mesh);
+        broadcastCreate();
+    }
+
+    @HostAccess.Export
+    public void remove() {
+        broadcastRemove();
+        ALL_MESHES.remove(meshId);
+        viewers.clear();
+        hiddenPlayers.clear();
+    }
+}


### PR DESCRIPTION
## Summary
- enable Veil dynamic buffers when rendering mesh proxies so they can be lit by Veil lights
- release the buffers when meshes are absent or during client cleanup to avoid leaving them active

## Testing
- ./gradlew :client-mod:check

------